### PR TITLE
squid:S1213 - The members of an interface declaration or class should…

### DIFF
--- a/app/src/main/java/com/qd/recorder/FFmpegRecorderActivity.java
+++ b/app/src/main/java/com/qd/recorder/FFmpegRecorderActivity.java
@@ -179,6 +179,14 @@ public class FFmpegRecorderActivity extends Activity implements OnClickListener,
 	private RecorderThread recorderThread;
 	
 	private Handler mHandler;
+
+	private boolean initSuccess = false;
+
+	//获取第一幀的图片
+	private boolean isFirstFrame = true;
+
+	private int mIntValue;
+
 	private void initHandler(){
 		mHandler = new Handler(){
 			@Override
@@ -243,7 +251,6 @@ public class FFmpegRecorderActivity extends Activity implements OnClickListener,
 	}
 
 	public native static int  checkNeonFromJNI();
-	private boolean initSuccess = false;
 
 	@Override
 	public void onCreate(Bundle savedInstanceState) {
@@ -722,10 +729,6 @@ public class FFmpegRecorderActivity extends Activity implements OnClickListener,
 		}
 	}
 	
-	//获取第一幀的图片
-	private boolean isFirstFrame = true;
-	
-		
 	/**
 	 * 显示摄像头的内容，以及返回摄像头的每一帧数据
 	 * @author QD
@@ -1282,7 +1285,11 @@ public class FFmpegRecorderActivity extends Activity implements OnClickListener,
 	
 	public enum RecorderState {
 		PRESS(1),LOOSEN(2),CHANGE(3),SUCCESS(4);
-		
+
+		RecorderState(int intValue) {
+			mIntValue = intValue;
+		}
+
 		static RecorderState mapIntToValue(final int stateInt) {
 			for (RecorderState value : RecorderState.values()) {
 				if (stateInt == value.getIntValue()) {
@@ -1290,12 +1297,6 @@ public class FFmpegRecorderActivity extends Activity implements OnClickListener,
 				}
 			}
 			return PRESS;
-		}
-
-		private int mIntValue;
-
-		RecorderState(int intValue) {
-			mIntValue = intValue;
 		}
 
 		int getIntValue() {

--- a/app/src/main/java/com/qd/recorder/NewFFmpegFrameRecorder.java
+++ b/app/src/main/java/com/qd/recorder/NewFFmpegFrameRecorder.java
@@ -83,10 +83,77 @@ import static com.googlecode.javacv.cpp.swscale.*;
  * @author Samuel Audet
  */
 public class NewFFmpegFrameRecorder extends FrameRecorder {
+
+    private String filename;
+    private AVFrame picture, tmp_picture;
+    private BytePointer picture_buf;
+    private BytePointer video_outbuf;
+    private int video_outbuf_size;
+    private AVFrame frame;
+    private Pointer[] samples_in;
+    private BytePointer[] samples_out;
+    private PointerPointer samples_in_ptr;
+    private PointerPointer samples_out_ptr;
+    private BytePointer audio_outbuf;
+    private int audio_outbuf_size;
+    private int audio_input_frame_size;
+    private AVOutputFormat oformat;
+    private AVFormatContext oc;
+    private AVCodec video_codec, audio_codec;
+    private AVCodecContext video_c, audio_c;
+    private AVStream video_st, audio_st;
+    private SwsContext img_convert_ctx;
+    private SwrContext samples_convert_ctx;
+    private AVPacket video_pkt, audio_pkt;
+    private int[] got_video_packet, got_audio_packet;
+
+    private static Exception loadingException = null;
+
+    public NewFFmpegFrameRecorder(File file, int audioChannels) {
+        this(file, 0, 0, audioChannels);
+    }
+
+    public NewFFmpegFrameRecorder(String filename, int audioChannels) {
+        this(filename, 0, 0, audioChannels);
+    }
+
+    public NewFFmpegFrameRecorder(File file, int imageWidth, int imageHeight) {
+        this(file, imageWidth, imageHeight, 0);
+    }
+
+    public NewFFmpegFrameRecorder(String filename, int imageWidth, int imageHeight) {
+        this(filename, imageWidth, imageHeight, 0);
+    }
+
+    public NewFFmpegFrameRecorder(File file, int imageWidth, int imageHeight, int audioChannels) {
+        this(file.getAbsolutePath(), imageWidth, imageHeight);
+    }
+
+    public NewFFmpegFrameRecorder(String filename, int imageWidth, int imageHeight, int audioChannels) {
+        this.filename      = filename;
+        this.imageWidth    = imageWidth;
+        this.imageHeight   = imageHeight;
+        this.audioChannels = audioChannels;
+
+        this.pixelFormat   = AV_PIX_FMT_NONE;
+        this.videoCodec    = AV_CODEC_ID_NONE;
+        this.videoBitrate  = 400000;
+        this.frameRate     = 30;
+
+        this.sampleFormat  = AV_SAMPLE_FMT_NONE;
+        this.audioCodec    = AV_CODEC_ID_NONE;
+        this.audioBitrate  = 64000;
+        this.sampleRate    = 44100;
+
+        this.interleaved = true;
+
+        this.video_pkt = new AVPacket();
+        this.audio_pkt = new AVPacket();
+    }
+
     public static NewFFmpegFrameRecorder createDefault(File f, int w, int h)   throws Exception { return new NewFFmpegFrameRecorder(f, w, h); }
     public static NewFFmpegFrameRecorder createDefault(String f, int w, int h) throws Exception { return new NewFFmpegFrameRecorder(f, w, h); }
 
-    private static Exception loadingException = null;
     public static void tryLoad() throws Exception {
         if (loadingException != null) {
             throw loadingException;
@@ -112,42 +179,6 @@ public class NewFFmpegFrameRecorder extends FrameRecorder {
         avformat_network_init();
     }
 
-    public NewFFmpegFrameRecorder(File file, int audioChannels) {
-        this(file, 0, 0, audioChannels);
-    }
-    public NewFFmpegFrameRecorder(String filename, int audioChannels) {
-        this(filename, 0, 0, audioChannels);
-    }
-    public NewFFmpegFrameRecorder(File file, int imageWidth, int imageHeight) {
-        this(file, imageWidth, imageHeight, 0);
-    }
-    public NewFFmpegFrameRecorder(String filename, int imageWidth, int imageHeight) {
-        this(filename, imageWidth, imageHeight, 0);
-    }
-    public NewFFmpegFrameRecorder(File file, int imageWidth, int imageHeight, int audioChannels) {
-        this(file.getAbsolutePath(), imageWidth, imageHeight);
-    }
-    public NewFFmpegFrameRecorder(String filename, int imageWidth, int imageHeight, int audioChannels) {
-        this.filename      = filename;
-        this.imageWidth    = imageWidth;
-        this.imageHeight   = imageHeight;
-        this.audioChannels = audioChannels;
-
-        this.pixelFormat   = AV_PIX_FMT_NONE;
-        this.videoCodec    = AV_CODEC_ID_NONE;
-        this.videoBitrate  = 400000;
-        this.frameRate     = 30;
-
-        this.sampleFormat  = AV_SAMPLE_FMT_NONE;
-        this.audioCodec    = AV_CODEC_ID_NONE;
-        this.audioBitrate  = 64000;
-        this.sampleRate    = 44100;
-
-        this.interleaved = true;
-
-        this.video_pkt = new AVPacket();
-        this.audio_pkt = new AVPacket();
-    }
     public void release() throws Exception {
         synchronized (com.googlecode.javacv.cpp.avcodec.class) {
             releaseUnsafe();
@@ -228,29 +259,6 @@ public class NewFFmpegFrameRecorder extends FrameRecorder {
         super.finalize();
         release();
     }
-
-    private String filename;
-    private AVFrame picture, tmp_picture;
-    private BytePointer picture_buf;
-    private BytePointer video_outbuf;
-    private int video_outbuf_size;
-    private AVFrame frame;
-    private Pointer[] samples_in;
-    private BytePointer[] samples_out;
-    private PointerPointer samples_in_ptr;
-    private PointerPointer samples_out_ptr;
-    private BytePointer audio_outbuf;
-    private int audio_outbuf_size;
-    private int audio_input_frame_size;
-    private AVOutputFormat oformat;
-    private AVFormatContext oc;
-    private AVCodec video_codec, audio_codec;
-    private AVCodecContext video_c, audio_c;
-    private AVStream video_st, audio_st;
-    private SwsContext img_convert_ctx;
-    private SwrContext samples_convert_ctx;
-    private AVPacket video_pkt, audio_pkt;
-    private int[] got_video_packet, got_audio_packet;
 
     @Override public int getFrameNumber() {
         return picture == null ? super.getFrameNumber() : (int)picture.pts();

--- a/app/src/main/java/com/qd/recorder/ProgressView.java
+++ b/app/src/main/java/com/qd/recorder/ProgressView.java
@@ -14,6 +14,19 @@ import android.view.View;
 
 public class ProgressView extends View
 {
+	private Paint progressPaint, firstPaint, threePaint,breakPaint;//三个颜色的画笔
+	private float firstWidth = 4f, threeWidth = 1f;//断点的宽度
+	private LinkedList<Integer> linkedList = new LinkedList<Integer>();
+	private float perPixel = 0l;
+	private float countRecorderTime = 6000;//总的录制时间
+
+	private volatile State currentState = State.PAUSE;//当前状态
+	private boolean isVisible = true;//一闪一闪的黄色区域是否可见
+	private float countWidth = 0;//每次绘制完成，进度条的长度
+	private float perProgress = 0;//手指按下时，进度条每次增长的长度
+	private float perSecProgress = 0;//每毫秒对应的像素点
+	private long initTime;//绘制完成时的时间戳
+	private long drawFlashTime = 0;//闪动的黄色区域时间戳
 
 	public ProgressView(Context context) {
 		super(context);
@@ -31,12 +44,6 @@ public class ProgressView extends View
 		super(paramContext, paramAttributeSet, paramInt);
 		init(paramContext);
 	}
-
-	private Paint progressPaint, firstPaint, threePaint,breakPaint;//三个颜色的画笔
-	private float firstWidth = 4f, threeWidth = 1f;//断点的宽度
-	private LinkedList<Integer> linkedList = new LinkedList<Integer>();
-	private float perPixel = 0l;
-	private float countRecorderTime = 6000;//总的录制时间
 
 	public void setTotalTime(float time){
 		countRecorderTime = time;
@@ -83,6 +90,12 @@ public class ProgressView extends View
 	public static enum State {
 		START(0x1),PAUSE(0x2);
 
+		private int mIntValue;
+
+		State(int intValue) {
+			mIntValue = intValue;
+		}
+
 		static State mapIntToValue(final int stateInt) {
 			for (State value : State.values()) {
 				if (stateInt == value.getIntValue()) {
@@ -92,25 +105,10 @@ public class ProgressView extends View
 			return PAUSE;
 		}
 
-		private int mIntValue;
-
-		State(int intValue) {
-			mIntValue = intValue;
-		}
-
 		int getIntValue() {
 			return mIntValue;
 		}
 	}
-
-
-	private volatile State currentState = State.PAUSE;//当前状态
-	private boolean isVisible = true;//一闪一闪的黄色区域是否可见
-	private float countWidth = 0;//每次绘制完成，进度条的长度
-	private float perProgress = 0;//手指按下时，进度条每次增长的长度
-	private float perSecProgress = 0;//每毫秒对应的像素点
-	private long initTime;//绘制完成时的时间戳
-	private long drawFlashTime = 0;//闪动的黄色区域时间戳
 
 	protected void onDraw(Canvas canvas) {
 		super.onDraw(canvas);

--- a/app/src/main/java/com/qd/recorder/SavedFrames.java
+++ b/app/src/main/java/com/qd/recorder/SavedFrames.java
@@ -6,12 +6,38 @@ import android.os.Parcelable;
 
 
 public class SavedFrames implements Parcelable{
-	
+
 	private byte[] frameBytesData = null;
 	private long timeStamp = 0L;
 	private String cachePath = null;
 	private int frameSize = 0;
-	 
+
+	public static final Creator<SavedFrames> CREATOR = new Creator<SavedFrames>() {
+		@Override
+		public SavedFrames createFromParcel(Parcel paramParcel) {
+			SavedFrames savedFrame = new SavedFrames();
+			savedFrame.readFromParcel(paramParcel);
+			return savedFrame;
+		}
+
+		@Override
+		public SavedFrames[] newArray(int paramInt) {
+			return new SavedFrames[paramInt];
+		}
+	};
+	public SavedFrames(byte[] frameBytesData, long timeStamp) {
+		this.frameBytesData = frameBytesData;
+		this.timeStamp = timeStamp;
+	}
+	public SavedFrames(Parcel in) {
+		readFromParcel(in);
+	}
+	public SavedFrames() {
+		frameSize = 0;
+		frameBytesData = new byte[0];
+		timeStamp = 0L;
+		cachePath = null;
+	}
 	public byte[] getFrameBytesData() {
 		return frameBytesData;
 	}
@@ -24,14 +50,7 @@ public class SavedFrames implements Parcelable{
 	public void setTimeStamp(long timeStamp) {
 		this.timeStamp = timeStamp;
 	}
-	 
-	 public SavedFrames(byte[] frameBytesData, long timeStamp)
-	 {
-		 this.frameBytesData = frameBytesData;
-		 this.timeStamp = timeStamp;
-	 }
 
-	
 	public String getCachePath() {
 		return cachePath;
 	}
@@ -45,36 +64,6 @@ public class SavedFrames implements Parcelable{
 	public void setframeSize(int frameSize) {
 		this.frameSize = frameSize;
 	}
-	
-	public SavedFrames(Parcel in)
-	{
-		readFromParcel(in);
-	}
-
-	public SavedFrames()
-	{
-		frameSize = 0;
-		frameBytesData =  new byte[0];
-		timeStamp = 0L;
-		cachePath = null;
-	}
-
-	public static final Creator<SavedFrames> CREATOR = new Creator<SavedFrames>()
-	{
-		@Override
-		public SavedFrames createFromParcel(Parcel paramParcel)
-		{
-			SavedFrames savedFrame = new SavedFrames();
-			savedFrame.readFromParcel(paramParcel);
-			return savedFrame;
-		}
-
-		@Override
-		public SavedFrames[] newArray(int paramInt)
-		{
-			return new SavedFrames[paramInt];
-		}
-	};
 
 	@Override
 	public int describeContents()

--- a/app/src/main/java/com/qd/recorder/VideoPlayTextureView.java
+++ b/app/src/main/java/com/qd/recorder/VideoPlayTextureView.java
@@ -21,14 +21,6 @@ public class VideoPlayTextureView extends TextureView implements
 	private MediaState currentMediaState = MediaState.RESET;
 	private boolean isChange = true;//当加载完视频文件时，判断当前SurfaceView是否还是之前的SurfaceView
 
-	public void setChange(boolean change){
-		isChange = change;
-	}
-
-	public boolean isChange(){
-		return isChange;
-	}
-
 	public VideoPlayTextureView(Context context) {
 		super(context);
 		init(context);
@@ -43,6 +35,14 @@ public class VideoPlayTextureView extends TextureView implements
 								AttributeSet paramAttributeSet, int paramInt) {
 		super(paramContext, paramAttributeSet, paramInt);
 		init(paramContext);
+	}
+
+	public void setChange(boolean change){
+		isChange = change;
+	}
+
+	public boolean isChange(){
+		return isChange;
 	}
 
 	/**
@@ -168,6 +168,13 @@ public class VideoPlayTextureView extends TextureView implements
 	 */
 	public enum MediaState {
 		RESET(0x5),PREPARE(0x1), COMPLETE(0x2), PLAY(0x3), PAUSE(0x4);
+
+		private int mIntValue;
+
+		MediaState(int intValue) {
+			mIntValue = intValue;
+		}
+
 		static MediaState mapIntToValue(final int stateInt) {
 			for (MediaState value : MediaState.values()) {
 				if (stateInt == value.getIntValue()) {
@@ -175,12 +182,6 @@ public class VideoPlayTextureView extends TextureView implements
 				}
 			}
 			return RESET;
-		}
-
-		private int mIntValue;
-
-		MediaState(int intValue) {
-			mIntValue = intValue;
 		}
 
 		int getIntValue() {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1213

Please let me know if you have any questions.

M-Ezzat